### PR TITLE
fix: Save Deployment "Already exists" on new names 

### DIFF
--- a/script/BaseScript.sol
+++ b/script/BaseScript.sol
@@ -147,7 +147,7 @@ contract BaseScript is Script {
     internal
   {
     vm.label(_contractAddress, _contractName);
-    if (_isSimulation()) return;
+    // if (_isSimulation()) return;
 
     string memory json = "NewDeployment";
     string memory insertData;
@@ -158,10 +158,7 @@ contract BaseScript is Script {
     string memory currentData = vm.readFile(_getDeploymentPath(_getNetwork()));
     strings.slice memory slicedCurrentData = currentData.toSlice();
 
-    if (
-      slicedCurrentData.contains(_contractName.toSlice())
-        || slicedCurrentData.contains(string(abi.encodePacked(_contractAddress)).toSlice())
-    ) {
+    if (contracts[_contractName] != address(0)) {
       console.log(_contractName, "Already exists");
       return;
     }
@@ -174,6 +171,8 @@ contract BaseScript is Script {
     }
 
     vm.writeJson(insertData, _getDeploymentPath(_getNetwork()));
+
+    contracts[_contractName] = _contractAddress;
   }
 
   function _addContractToString(string memory _currentData, string memory _contractData)

--- a/script/BaseScript.sol
+++ b/script/BaseScript.sol
@@ -147,7 +147,7 @@ contract BaseScript is Script {
     internal
   {
     vm.label(_contractAddress, _contractName);
-    // if (_isSimulation()) return;
+    if (_isSimulation()) return;
 
     string memory json = "NewDeployment";
     string memory insertData;


### PR DESCRIPTION
The check was inspecting each character, so if, for example, you had the string 'HelloWorld' and the new deployment was 'World', 'World' wouldn't be saved as it already exists within the original string.

Looking back at it, it was doing useless check and it was over complicated for no reason.